### PR TITLE
Confirm and Submit Buttons

### DIFF
--- a/static/js/geopaths.js
+++ b/static/js/geopaths.js
@@ -1,78 +1,44 @@
+/* ************ MAIN ************ */
 
-//leaflet has layer toggles, could have one map, button toggles the main layer off, cumaltive submissions from user
 // Declare global variables
 var coord_array = []
 var UPDATE_INTERVAL = 30000; //unis of ms
-<<<<<<< HEAD
-var geocoderResults;
-//marker array
-=======
+
 //Create new grouping of non-user-submitted paths.
 //We will add paths to the group as they are retrieved from the db.
 var strangers_layer_group = L.layerGroup();
->>>>>>> origin/master
+
 // Show the whole world in this first view.
 var map = L.map('map', {
-    bounceAtZoomLimits: true,
-	 maxBounds:
-	 [[-85.0, -180.0],
-        [85.0, 180.0]],
-    inertia: false,
+  bounceAtZoomLimits: true,
+  maxBounds: [[-85.0, -180.0],[85.0, 180.0]],
+  inertia: false,
 	minZoom: 2,
 	continuousWorld: false,
 	layers: [strangers_layer_group]
 }).setView([20, 0], 2);
 L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
-// LOOKS LIKE MAPZEN KEY HAS TO BE ON FRONT END
-var options =
-{
-  position: 'topright'
-}
-var geocoder =  L.control.geocoder('search-daf-vyw', options).addTo(map);
 
-// Transform a GeoJSON string '{type:"Point",coordinates:[x,y]}'
-// into a leaflet LatLng object
-function geoJSONToLLatLng(ptStr) {
-  var p = JSON.parse(ptStr);
-  return new L.LatLng(p.coordinates[1],p.coordinates[0]);
-}
-
-<<<<<<< HEAD
-// REMOVED KEYS
-// REMOVED LOADING FROM CARTODB DIRECTLY TO AVOID HAVING KEYS ON FRONT END
-/*geoj.rows.forEach(function(row,i){
-  if(row.p1 != null && row.p2 != null){
-    var latlngs = [geoJSONToLLatLng(row.p1),geoJSONToLLatLng(row.p2)];
-    var line = L.polyline(latlngs,{snakingSpeed: 200}); 
-    line.addTo(map).snakeIn();
-  }
-})*/
+var geocoder_options = {position: 'topright'};
+var geocoder =  L.control.geocoder('search-daf-vyw', geocoder_options).addTo(map);
 
 
-
+// TODO: Choose: Add geojson straight to map or to layercontrol
 var geojsonFeature = geoj
 L.geoJson(geojsonFeature).addTo(map);
+geojsonFeature.addTo(map).snakeIn();
 
-=======
 // this loads data and does the inital animation
->>>>>>> origin/master
 geoj.rows.forEach(function(row,i){
   if(row.p1 != null && row.p2 != null){
     var latlngs = [geoJSONToLLatLng(row.p1),geoJSONToLLatLng(row.p2)];
     var line = L.polyline(latlngs,{snakingSpeed: 200}); 
     //add to layergroup instead of directly to map
-	strangers_layer_group.addLayer(line);
-	//line.addTo(map).snakeIn();
+	  strangers_layer_group.addLayer(line);
+	  //line.addTo(map).snakeIn();
   }
 })
 
-<<<<<<< HEAD
-geojsonFeature.addTo(map).snakeIn();
-//Gets new rows from the server and plots them.
-//update_map executes periodically and indefinitely until server returns error
-// It is also asynchronous, so control moves past this line
-//comment this for debugging
-=======
 //Create leaflet control to toggle map layers
 var overlayMaps = {
   "strangers": strangers_layer_group,
@@ -89,8 +55,20 @@ overlayMaps.strangers.eachLayer(function(x){x.snakeIn()});
 //Gets new rows from the server and plots them.
 //update_map executes periodically and indefinitely until server returns error
 // It is also asynchronous, so control moves past this line
->>>>>>> origin/master
-//update_map();
+//update_map(); //commented out while backend is in flux
+
+//commented out while front end is in flux
+//document.getElementById("submit_button").addEventListener("click", post_array);
+
+
+/* ************ FUNCTIONS *********** */
+
+// Transform a GeoJSON string '{type:"Point",coordinates:[x,y]}'
+//  into a leaflet LatLng object  */
+function geoJSONToLLatLng(ptStr) {
+  var p = JSON.parse(ptStr);
+  return new L.LatLng(p.coordinates[1],p.coordinates[0]);
+}
 
 //Gets new rows from the server and plots them.
 // Executes periodically and indefinitely until server returns an error.
@@ -161,8 +139,3 @@ function post_array() {
   }
 };
 
-<<<<<<< HEAD
-
-=======
->>>>>>> origin/master
-//document.getElementById("submit_button").addEventListener("click", post_array);

--- a/static/js/geopaths.js
+++ b/static/js/geopaths.js
@@ -27,21 +27,23 @@ geoj.features.forEach(function(feat){
   // Assume each feature is a Multipoint geometry
   // (which is ordered Long,Lat. Leaflet expects Lat,Long
   var coords = feat.geometry.coordinates.map(function(p){return p.reverse();});
+  
+  // Skip route if any coordinate is null
+  if(coords.reduce(function(notNull,coord){return notNull && coord != null;},true)){
+    
+    // Create layer group for a route.
+    var route = L.featureGroup([L.marker(coords[0])]);
+    for (var i = 1; i < coords.length; i ++){
+      route.addLayer(L.polyline([coords[i-1],coords[i]]));
+      route.addLayer(L.marker(coords[i]));
+    }
 
-  // Create layer group for each route.
-  var route = L.featureGroup([L.marker(coords[0])]);
-  for (var i = 1; i < coords.length; i ++){
-    route.addLayer(L.polyline([coords[i-1],coords[i]]));
-    route.addLayer(L.marker(coords[i]));
+    //Add route layer group to grouping of all non-user routes
+    strangers_layer_group.addLayer(route);
+
   }
   
-  //Add route layer group to grouping of all non-user routes
-  strangers_layer_group.addLayer(route);
 });
-
-/* Alternatively, add geoJson straight to group.
- * strangers_layer_group.addLayer(L.geoJson(geoj));
- */
 
 //Create leaflet control to toggle map layers
 var baseMaps = {

--- a/static/js/geopaths.js
+++ b/static/js/geopaths.js
@@ -22,7 +22,7 @@ L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
 var geocoder_options = {position: 'topright'};
 var geocoder =  L.control.geocoder('search-daf-vyw', geocoder_options).addTo(map);
 
-// this loads data and does the inital animation
+// this loads data into a leaflet layer
 geoj.features.forEach(function(feat){
   // Assume each feature is a Multipoint geometry
   // (which is ordered Long,Lat. Leaflet expects Lat,Long
@@ -44,6 +44,11 @@ geoj.features.forEach(function(feat){
   }
   
 });
+// Do initial animation:
+//Snakein on each layer animates all at once
+strangers_layer_group.eachLayer(function(x){x.snakeIn()});
+//Snakein on the layergroup animates one at a time
+//strangers_layer_group.snakeIn();
 
 //Create leaflet control to toggle map layers
 var baseMaps = {
@@ -53,10 +58,6 @@ var baseMaps = {
 var overlayControl = L.control.layers(baseMaps);
 overlayControl.options.position = 'bottomright';
 overlayControl.addTo(map);
-//Snakein on each layer animates all at once
-overlayMaps.strangers.eachLayer(function(x){x.snakeIn()});
-//Snakein on the layergroup animates one at a time
-//overlayMaps.strangers.snakeIn();
 
 //Gets new rows from the server and plots them.
 //update_map executes periodically and indefinitely until server returns error

--- a/static/js/geopaths.js
+++ b/static/js/geopaths.js
@@ -106,7 +106,7 @@ function update_map() {
   });
 }
 
-function addMarkerToArray(coordPair) {
+function confirmCoord(coordPair) {
     coord_array.push(coordPair);
 }
 

--- a/static/js/geopaths.js
+++ b/static/js/geopaths.js
@@ -1,9 +1,12 @@
 /* ************ MAIN ************ */
 
 // Declare global variables
-var coord_array = []
 var UPDATE_INTERVAL = 30000; //unis of ms
 var geocoderResults; //Referenced in Pelias js 
+
+//Create grouping for user-submitted results.
+//We will add points to the group as they are geocoded & confirmed by user.
+var confirmed_pts = L.layerGroup();
 
 //Create new grouping of non-user-submitted paths.
 //We will add paths to the group as they are retrieved from the db.
@@ -16,7 +19,7 @@ var map = L.map('map', {
   inertia: false,
   minZoom: 2,
   continuousWorld: false,
-  layers: [strangers_layer_group] //layers added here are shown by default
+  layers: [confirmed_pts,strangers_layer_group] //layers added here are shown by default
 }).setView([20, 0], 2);
 L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
 
@@ -56,7 +59,10 @@ var baseMaps = {
   "strangers": strangers_layer_group,
   "none" : L.layerGroup()
 };
-var overlayControl = L.control.layers(baseMaps);
+var overlayMaps = {
+  "user": confirmed_pts
+};
+var overlayControl = L.control.layers(baseMaps,overlayMaps);
 overlayControl.options.position = 'bottomright';
 overlayControl.addTo(map);
 
@@ -107,7 +113,7 @@ function update_map() {
 }
 
 function confirmCoord(coordPair) {
-    coord_array.push(coordPair);
+    confirmed_pts.addLayer(L.marker(coordPair));
 }
 
 function post_array() {

--- a/static/js/geopaths.js
+++ b/static/js/geopaths.js
@@ -3,6 +3,7 @@
 // Declare global variables
 var coord_array = []
 var UPDATE_INTERVAL = 30000; //unis of ms
+var geocoderResults; //Referenced in Pelias js 
 
 //Create new grouping of non-user-submitted paths.
 //We will add paths to the group as they are retrieved from the db.

--- a/static/js/geopaths.js
+++ b/static/js/geopaths.js
@@ -60,7 +60,7 @@ var baseMaps = {
   "none" : L.layerGroup()
 };
 var overlayMaps = {
-  "user": confirmed_pts
+  "confirmed": confirmed_pts
 };
 var overlayControl = L.control.layers(baseMaps,overlayMaps);
 overlayControl.options.position = 'bottomright';
@@ -112,12 +112,41 @@ function update_map() {
   });
 }
 
+//Handle user clicking 'Confirm' button.
 function confirmCoord(coordPair) {
-    confirmed_pts.addLayer(L.marker(coordPair));
+  
+    //Show confirmation
+    var confirmation_msg = document.createElement('div');
+    confirmation_msg.innerHTML = "Point Added. <br />";
+    var confirmed_mark = L.marker(coordPair).bindPopup(confirmation_msg);
+    confirmed_pts.addLayer(confirmed_mark);
+
+    if (allowSubmit()){
+      addSubmitBtn(confirmed_mark);
+    }
+
+    confirmed_mark.openPopup();
+}
+
+function addSubmitBtn(confirmed_mark){
+  var submitBtn = document.createElement('a');
+  submitBtn.className = "btn btn-default";
+  submitBtn.innerHTML = "Submit";
+  submitBtn.addEventListener('click',function(){
+    //Prevent doubletap
+    map.closePopup();
+    post_array();
+  });
+  confirmed_mark.getPopup().getContent().appendChild(submitBtn);
+}
+
+function allowSubmit(){
+  return confirmed_pts.getLayers().length >= 2;
 }
 
 function post_array() {
-  if (geocoder.markers.length >= 2) {
+  alert('posted but not really');
+  /*if (geocoder.markers.length >= 2) {
       
         // take each marker from the geocoder layer and map it to a new array
         var data = [];
@@ -151,5 +180,6 @@ function post_array() {
   else {
     document.getElementById("array-warn").innerText = "Please select at least two points before submitting";
   }
+  */
 };
 

--- a/static/js/pelias-leaflet-geocoder.js
+++ b/static/js/pelias-leaflet-geocoder.js
@@ -298,7 +298,11 @@
         var confirmBtn = document.createElement("a");
         confirmBtn.className = "btn btn-default";
         confirmBtn.innerHTML = "Confirm";
-        confirmBtn.addEventListener('click',function(){confirmCoord(geo);});
+        confirmBtn.addEventListener('click',function(){
+          // Prevent doubletap
+          map.closePopup();
+          confirmCoord(geo);
+        });
         var popupContent = document.createElement("div");
         popupContent.innerHTML = text + "<br />";
         popupContent.appendChild(confirmBtn);

--- a/static/js/pelias-leaflet-geocoder.js
+++ b/static/js/pelias-leaflet-geocoder.js
@@ -295,9 +295,15 @@
       var markerOptions = (typeof this.options.markers === 'object') ? this.options.markers : {};
 
       if (this.options.markers) {
-        this.marker = new L.marker(geo, markerOptions).bindPopup(text + "<br /><a class='btn btn-default'>Confirm</a>"); // eslint-disable-line new-cap
+        var confirmBtn = document.createElement("a");
+        confirmBtn.className = "btn btn-default";
+        confirmBtn.innerHTML = "Confirm";
+        confirmBtn.addEventListener('click',function(){confirmCoord(geo);});
+        var popupContent = document.createElement("div");
+        popupContent.innerHTML = text + "<br />";
+        popupContent.appendChild(confirmBtn);
+        this.marker = new L.marker(geo, markerOptions).bindPopup(popupContent); // eslint-disable-line new-cap
         this.marker.location_text = place.name;
-        this.marker.on('click',function(){addMarkerToArray(geo);});
         this.marker.country = place.country;
         this._map.addLayer(this.marker);
         this.markers.push(this.marker);


### PR DESCRIPTION
Completes Issue #35 except:
- Styling of user-submitted markers isn't different.
- The search box does not reset after each submission.
- The 'stranger' layer isn't toggled off or on while the user is confirming and submitting.

I've chosen to put the 'Submit' button also in the marker popup. We should still have examples and prompts and redundant buttons somewhere else on the page, but it is convenient to not have to leave the map once the user knows what to do. 
